### PR TITLE
[fix] Fixed misunderstand of the original API

### DIFF
--- a/packages/animation-builder/src/builder_items/AngleCircle.ts
+++ b/packages/animation-builder/src/builder_items/AngleCircle.ts
@@ -32,7 +32,7 @@ export class AngleCircle extends AnimationBuilderItem {
       throw new Error(`be unset data "${flag}"`);
     datas.from = datas.from ?? [datas.bindTo.startAngle, datas.bindTo.endAngle];
     this.#datas = {
-      length: datas.lastsFor - datas.startAt,
+      length: datas.lastsFor,
       start: datas.startAt,
       obj: datas.bindTo,
       interpolatorstart: new Interpolator(

--- a/packages/animation-builder/src/builder_items/ChangingStatus.ts
+++ b/packages/animation-builder/src/builder_items/ChangingStatus.ts
@@ -22,7 +22,7 @@ export class ChangingStatus extends AnimationBuilderItem {
     )
       throw new Error(`be unset data "${flag}"`);
     this.#datas = {
-      length: datas.lastsFor - datas.startAt,
+      length: datas.lastsFor,
       start: datas.startAt,
       obj: datas.bindTo,
     };

--- a/packages/animation-builder/src/builder_items/Rotation.ts
+++ b/packages/animation-builder/src/builder_items/Rotation.ts
@@ -35,7 +35,7 @@ export class Rotation extends AnimationBuilderItem {
       start: datas.startAt,
       obj: datas.bindTo,
       interpolator: new Interpolator(datas.from, datas.to, datas.by ?? LinearInterpolator),
-      length: datas.lastsFor - datas.startAt,
+      length: datas.lastsFor,
     };
   }
 

--- a/packages/animation-builder/src/builder_items/Scale.ts
+++ b/packages/animation-builder/src/builder_items/Scale.ts
@@ -36,7 +36,7 @@ export class Scale extends AnimationBuilderItem {
       obj: datas.bindTo,
       interpolatorx: new Interpolator(datas.from[0], datas.to[0], datas.by ?? LinearInterpolator),
       interpolatory: new Interpolator(datas.from[1], datas.to[1], datas.by ?? LinearInterpolator),
-      length: datas.lastsFor - datas.startAt,
+      length: datas.lastsFor,
       start: datas.startAt,
     };
   }

--- a/packages/animation-builder/src/builder_items/Translation.ts
+++ b/packages/animation-builder/src/builder_items/Translation.ts
@@ -33,7 +33,7 @@ export class Translation extends AnimationBuilderItem {
       throw new Error(`be unset data "${flag}"`);
     datas.from = datas.from ?? [datas.bindTo.x, datas.bindTo.y];
     this.#datas = {
-      length: datas.lastsFor - datas.startAt ?? null,
+      length: datas.lastsFor ?? null,
       start: datas.startAt ?? null,
       obj: datas.bindTo ?? null,
       interpolatorx: new Interpolator(datas.from[0], datas.to[0], datas.by ?? LinearInterpolator),

--- a/packages/animation-builder/src/builder_items/index.ts
+++ b/packages/animation-builder/src/builder_items/index.ts
@@ -6,8 +6,9 @@ import { Limit } from "./Limit";
 import { AngleCircle } from "./AngleCircle";
 import { SingleFrameAction } from "./SingleFrameAction";
 import { MutateContent } from "./MutateContent";
+import { AnimationBuilderItem } from "../AnimationBuilderItem";
 
-export const animation = ((exports: Record<string, any>) => {
+export const animation = ((exports: Record<string, unknown>) => {
   exports.Translation = Translation;
   exports.Rotation = Rotation;
   exports.Scale = Scale;


### PR DESCRIPTION
The author of commit `1f21e505a46131f1ce9335af9e9fa77844155bd3` (@PrairieFire2b ) seemed to have some misunderstanding with my naming, and that lead to incorrect functionalities to a few APIs. I've corrected those functionalities in this commit. Known misunderstandings includes that `lastsFor` is literally `length`, so the `lastsFor - startAt` is meaningless and should be corrected as `lastsFor`, and to get the last frame you need to calculate `startAt + lastsFor`.
